### PR TITLE
Fix zoom out feature

### DIFF
--- a/components/Canvas.jsx
+++ b/components/Canvas.jsx
@@ -672,7 +672,7 @@ const Canvas = () => {
         <TooltipProvider delayDuration={100}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button onClick={() => setscale(scale - 0.1)} variant="outline" size="icon" className="h-8 w-8" >
+              <Button onClick={() => setscale((prev)=>(prev - 0.1 < 0.1 ? 0.1 : prev-0.1))} variant="outline" size="icon" className="h-8 w-8" >
                 <ChevronLeft className="h-4 w-4" />
               </Button>
 


### PR DESCRIPTION
fixes #11 
issue Pressing zoom out button multiple times makes the canvas see upside down is solved by this PR by changing the code to zoom out with the chevron left button .