### PR TITLE
Font style

### DIFF
--- a/components/FontStyle.jsx
+++ b/components/FontStyle.jsx
@@ -1,0 +1,48 @@
+import React, { useState, useEffect } from 'react';
+
+const FontSelector = () => {
+  const [fonts, setFonts] = useState([]);
+  const [selectedFont, setSelectedFont] = useState('');
+
+  useEffect(() => {
+    const fetchFonts = async () => {
+      try {
+        const response = await fetch(
+          'https://www.googleapis.com/webfonts/v1/webfonts?key=AIzaSyDyKSpUQnj3o9fSPh8LCCN4rY9PoBV7TJ4'
+        );
+        const data = await response.json();
+        setFonts(data.items.map((item) => item.family));
+      } catch (error) {
+        console.error('Error fetching fonts:', error);
+      }
+    };
+
+    fetchFonts();
+  }, []);
+
+  const handleFontChange = (e) => {
+    setSelectedFont(e.target.value);
+  };
+
+  return (
+    <div>
+        <span className='text-xs'>Font-Style</span>
+        <div>
+      <select value={selectedFont} onChange={handleFontChange}
+       
+       className="p-1.5 text-center text-sm  rounded-md mt-2 bg-[#ffffff] border-[1.5px] border-black"
+      >
+        {fonts.map((font) => (
+          <option key={font} value={font} 
+          >
+        {font}
+          </option>
+        ))}
+        
+      </select>
+      </div>
+    </div>
+  );
+};
+
+export default FontSelector;

--- a/components/PropertiesBar/PropertiesBar.jsx
+++ b/components/PropertiesBar/PropertiesBar.jsx
@@ -15,6 +15,7 @@ import { setElement } from '../Redux/features/elementSlice'
 
 import { MdRoundedCorner } from "react-icons/md"
 import { GlobalProps } from '../Redux/GlobalProps'
+import FontSelector from "../fonts"
 
 
 const PropertiesBar = () => {
@@ -355,6 +356,9 @@ const PropertiesBar = () => {
 
                     </CardContent>
                         : null}
+                {/*FontStyle start */}
+                    <FontSelector/>
+                {/*FontStyle end*/}
 
                     {(tool != 'text' && selectedElement === null) || (selectedElement != null && selectedElement.type != 'text') ? <CardContent>
                         <span className='text-xs'>Stroke width</span>


### PR DESCRIPTION
### Used Fonts  Google API
FontStyle is added to PropertiesBar ,But I coudn't apply that to the canva text 
![image](https://github.com/dhruvpatidar359/nextdraw/assets/116823590/21867b28-b635-4455-be9f-74328c296a42)
